### PR TITLE
Add `.gitignore` to Bots dir

### DIFF
--- a/Chess-Challenge/src/Bots/.gitignore
+++ b/Chess-Challenge/src/Bots/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This is an extra layer of security to prevent accidents, in case a non `.cs` source code file accidentally ends up here and you push it.
You could remove the readme now, or not (and exclude it in this file), up to you 😄 